### PR TITLE
Update SlackMessageForwarder.java

### DIFF
--- a/examples/lambda/src/main/java/com/mparticle/sdk/samples/SlackMessageForwarder.java
+++ b/examples/lambda/src/main/java/com/mparticle/sdk/samples/SlackMessageForwarder.java
@@ -118,7 +118,7 @@ public final class SlackMessageForwarder extends MessageProcessor {
         SlackPayload payload = new SlackPayload();
         payload.channel = channelName;
         payload.username = "LambdaForwarder";
-        payload.icon_url = "http://static.mparticle.com/public/mp-icon.png";
+        payload.icon_url = "https://static.mparticle.com/public/mp-icon.png";
         payload.text = messageText;
 
         try(CloseableHttpClient httpClient = HttpClients.createDefault()){


### PR DESCRIPTION
http->https for the slack logo sourced from static.mparticle.com

# Summary

http://static.mparticle.com/public/mp-icon.png
becomes
https://static.mparticle.com/public/mp-icon.png