### PR TITLE
Add support in MessageProcessor for handling push_message_open events

### DIFF
--- a/sdk/src/main/java/com/mparticle/sdk/MessageProcessor.java
+++ b/sdk/src/main/java/com/mparticle/sdk/MessageProcessor.java
@@ -141,6 +141,10 @@ public abstract class MessageProcessor {
                     processPushMessageReceiptEvent((PushMessageReceiptEvent) e);
                     break;
 
+                case PUSH_MESSAGE_OPEN:
+                    processPushMessageOpenEvent((PushMessageOpenEvent) e);
+                    break;
+
                 case PRODUCT_ACTION:
                     processProductActionEvent((ProductActionEvent) e);
                     break;
@@ -228,6 +232,16 @@ public abstract class MessageProcessor {
      * @throws IOException
      */
     public void processPushMessageReceiptEvent(PushMessageReceiptEvent event) throws IOException {
+
+    }
+
+    /**
+     * Handler for processing PushMessageOpenEvent.
+     *
+     * @param event event
+     * @throws IOException
+     */
+    public void processPushMessageOpenEvent(PushMessageOpenEvent event) throws IOException {
 
     }
 


### PR DESCRIPTION
# Summary

When reviewing the Firehose SDK, I realized that MessageProcessor.processEventProcessingRequest didn't have switch case to handle push_message_open events. That event type is not mentioned in the documentation, though it does seem to be a valid case. I went ahead and added a callback for handling that event type. 

Feel free to close if push_message_open events should not be supported here.
